### PR TITLE
Camera Implementation 

### DIFF
--- a/bambulabs.go
+++ b/bambulabs.go
@@ -3,8 +3,6 @@ package bambulabs_api
 import (
 	"fmt"
 
-	"io"
-
 	_fan "github.com/torbenconto/bambulabs_api/fan"
 	"github.com/torbenconto/bambulabs_api/internal/camera"
 
@@ -54,7 +52,7 @@ func NewPrinter(config *PrinterConfig) *Printer {
 		cameraClient: camera.NewCameraClient(&camera.ClientConfig{
 			Hostname:   config.Host,
 			AccessCode: config.AccessCode,
-			Port:       8888,
+			Port:       6000,
 		}),
 	}
 }
@@ -220,6 +218,12 @@ func (p *Printer) Data() (Data, error) {
 }
 
 // region Get Data Functions
+
+// GetSerial returns the serial number of the printer.
+// This is used to identify the printer.
+func (p *Printer) GetSerial() string {
+	return p.serial
+}
 
 // GetPrinterState gets the current state of the printer.
 // This function is currently working but problems exist with the underlying.
@@ -531,12 +535,16 @@ func (p *Printer) DeleteFile(path string) error {
 // region Camera functions
 
 // CaptureFrame calls the underlying camera client to capture a frame from the printer.
-func (p *Printer) CaptureFrame() ([]byte, error) {
+func (p *Printer) CaptureCameraFrame() ([]byte, error) {
 	return p.cameraClient.CaptureFrame()
 }
 
-func (p *Printer) CreateCameraStream() (io.ReadCloser, error) {
-	return p.cameraClient.CreateCameraStream()
+func (p *Printer) StartCameraStream() (<-chan []byte, error) {
+	return p.cameraClient.StartStream()
 }
 
-//endregion
+func (p *Printer) StopCameraStream() {
+	p.cameraClient.StopStream()
+}
+
+// endregion

--- a/internal/camera/camera.go
+++ b/internal/camera/camera.go
@@ -1,0 +1,153 @@
+package camera
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+type CameraClient struct {
+	hostname   string
+	accessCode string
+	port       int
+	authPacket []byte
+}
+
+type ClientConfig struct {
+	Hostname   string
+	AccessCode string
+	Port       int
+}
+
+func NewCameraClient(config *ClientConfig) *CameraClient {
+	return &CameraClient{
+		hostname:   config.Hostname,
+		accessCode: config.AccessCode,
+		port:       config.Port,
+		authPacket: createAuthPacket("bblp", config.AccessCode),
+	}
+}
+
+func createAuthPacket(username, accessCode string) []byte {
+	buffer := make([]byte, 76)
+	offset := 0
+
+	// 0x40 as 4 bytes little-endian
+	binary.LittleEndian.PutUint32(buffer[offset:], 0x40)
+	offset += 4
+
+	// 0x3000 as 4 bytes little-endian
+	binary.LittleEndian.PutUint32(buffer[offset:], 0x3000)
+	offset += 4
+
+	// two 4-byte zeroes
+	binary.LittleEndian.PutUint32(buffer[offset:], 0)
+	offset += 4
+	binary.LittleEndian.PutUint32(buffer[offset:], 0)
+	offset += 4
+
+	// username, padded to 32 bytes
+	copy(buffer[offset:], []byte(username))
+	offset += 32
+
+	// accessCode, padded to 32 bytes
+	copy(buffer[offset:], []byte(accessCode))
+	offset += 32
+
+	return buffer
+}
+
+func (c *CameraClient) CaptureFrame() ([]byte, error) {
+	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", c.hostname, c.port), &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write(c.authPacket)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	jpegStart := []byte{0xff, 0xd8, 0xff, 0xe0}
+	jpegEnd := []byte{0xff, 0xd9}
+
+	for {
+		chunk := make([]byte, 4096)
+		n, err := conn.Read(chunk)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(chunk[:n])
+
+		frame, remainder := findJpeg(buf.Bytes(), jpegStart, jpegEnd)
+		if frame != nil {
+			return frame, nil
+		}
+		buf.Reset()
+		buf.Write(remainder)
+	}
+}
+
+func (c *CameraClient) CreateCameraStream() (io.ReadCloser, error) {
+	conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", c.hostname, c.port), &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = conn.Write(c.authPacket)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		defer conn.Close()
+		defer pw.Close()
+
+		var buf bytes.Buffer
+		jpegStart := []byte{0xff, 0xd8, 0xff, 0xe0}
+		jpegEnd := []byte{0xff, 0xd9}
+
+		for {
+			chunk := make([]byte, 4096)
+			n, err := conn.Read(chunk)
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			buf.Write(chunk[:n])
+
+			for {
+				frame, remainder := findJpeg(buf.Bytes(), jpegStart, jpegEnd)
+				if frame != nil {
+					_, err := pw.Write(frame)
+					if err != nil {
+						pw.CloseWithError(err)
+						return
+					}
+					buf.Reset()
+					buf.Write(remainder)
+				} else {
+					break
+				}
+			}
+		}
+	}()
+
+	return pr, nil
+}
+
+func findJpeg(buf, startMarker, endMarker []byte) ([]byte, []byte) {
+	start := bytes.Index(buf, startMarker)
+	end := bytes.Index(buf[start:], endMarker)
+	if start != -1 && end != -1 {
+		end += start + len(endMarker)
+		return buf[start:end], buf[end:]
+	}
+	return nil, buf
+}


### PR DESCRIPTION
Ported from https://github.com/mattcar15/bambu-connect/blob/main/bambu_connect/CameraClient.py.

This PR introduces new functions to the `Printer` struct to interact with the `CameraClient`. These functions allow capturing a single frame from the camera, starting a video stream, and stopping the video stream. The following functions have been added to the `Printer` struct.

`CaptureCameraFrame() ([]byte, error)`: Captures a single frame from the camera.
`StartCameraStream() (<-chan []byte, error)`: Starts the video stream from the camera.
`StopCameraStream()`: Stops the video stream from the camera.
