### PR TITLE
Better light reports

### DIFF
--- a/bambulabs.go
+++ b/bambulabs.go
@@ -2,7 +2,7 @@ package bambulabs_api
 
 import (
 	"fmt"
-  
+
 	_fan "github.com/torbenconto/bambulabs_api/fan"
 	"github.com/torbenconto/bambulabs_api/internal/camera"
 
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-  "github.com/torbenconto/bambulabs_api/hms"
+	"github.com/torbenconto/bambulabs_api/hms"
 	"github.com/torbenconto/bambulabs_api/internal/ftp"
 	"github.com/torbenconto/bambulabs_api/internal/mqtt"
 	_light "github.com/torbenconto/bambulabs_api/light"
@@ -136,6 +136,13 @@ func (p *Printer) Data() (Data, error) {
 		NozzleTemperature:       data.Print.NozzleTemper,
 		Sdcard:                  data.Print.Sdcard,
 		WifiSignal:              data.Print.WifiSignal,
+	}
+
+	for _, light := range data.Print.LightsReport {
+		final.LightReport = append(final.LightReport, LightReport{
+			Node: _light.Light(light.Node),
+			Mode: _light.Mode(light.Mode),
+		})
 	}
 
 	colors := make([]color.RGBA, 0)

--- a/data.go
+++ b/data.go
@@ -1,6 +1,7 @@
 package bambulabs_api
 
 import (
+	_light "github.com/torbenconto/bambulabs_api/light"
 	"image/color"
 	"reflect"
 
@@ -30,6 +31,11 @@ type Ams struct {
 	Trays       []Tray  `json:"trays"`       // List of trays in the Ams
 }
 
+type LightReport struct {
+	Node _light.Light
+	Mode _light.Mode
+}
+
 type Data struct {
 	Ams                     []Ams            `json:"ams"`                        // List of Ams objects
 	AmsExists               bool             `json:"ams_exists"`                 // Whether an Ams is connected
@@ -51,6 +57,7 @@ type Data struct {
 	NozzleTargetTemperature float64          `json:"nozzle_target_temperature"`  // Target nozzle temperature (°C)
 	NozzleTemperature       float64          `json:"nozzle_temperature"`         // Current nozzle temperature (°C)
 	Sdcard                  bool             `json:"sdcard"`                     // Whether an SD card is inserted
+	LightReport             []LightReport    `json:"lights_report"`              // Light report
 	VtTray                  Tray             `json:"vt_tray"`                    // Built-in tray for use without Ams
 	WifiSignal              string           `json:"wifi_signal"`                // Wi-Fi signal strength in dBm
 }

--- a/light/light.go
+++ b/light/light.go
@@ -4,15 +4,15 @@ type Light string
 
 const (
 	ChamberLight Light = "chamber_light"
-	PartLight    Light = "part_light"
+	WorkLight    Light = "work_light"
 )
 
 func (l Light) String() string {
 	switch l {
 	case ChamberLight:
 		return "Chamber light"
-	case PartLight:
-		return "Part light"
+	case WorkLight:
+		return "Work light"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
New feature for handling light reports:

* [`data.go`](diffhunk://#diff-079f478a262a2c961df30fe79ff1c1ebe2840ceb09ef967fafead93df4cbe1b9R34-R38): Added a new `LightReport` type with `Node` and `Mode` fields, and updated the `Data` struct to include a `LightReport` slice. [[1]](diffhunk://#diff-079f478a262a2c961df30fe79ff1c1ebe2840ceb09ef967fafead93df4cbe1b9R34-R38) [[2]](diffhunk://#diff-079f478a262a2c961df30fe79ff1c1ebe2840ceb09ef967fafead93df4cbe1b9R60)
* [`bambulabs.go`](diffhunk://#diff-ed465226a3bccf800e36b717c3ba0d06914ed69d1db3fa03bf1f180e046aa063R141-R147): Modified the `Printer`'s `Data` method to append light reports to the `final` data structure.

Code adjustments for light handling:

* [`data.go`](diffhunk://#diff-079f478a262a2c961df30fe79ff1c1ebe2840ceb09ef967fafead93df4cbe1b9R4): Imported the `_light` package to use the `Light` and `Mode` types.
* [`light/light.go`](diffhunk://#diff-15ce5192b09e4e55f311ea90ef4e6d41c203e1c26dacb7ad99ded1bd0c6649b9L7-R15): Updated the `Light` type to replace `PartLight` with `WorkLight` and adjusted the `String` method accordingly.