### PR TITLE
Add sequence id handling

### DIFF
--- a/internal/mqtt/command.go
+++ b/internal/mqtt/command.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"encoding/json"
+	"strconv"
 )
 
 type MessageType string
@@ -14,7 +15,7 @@ const (
 
 type Command struct {
 	Type MessageType
-	id   string
+	id   int
 
 	fields map[string]interface{}
 }
@@ -22,7 +23,7 @@ type Command struct {
 func NewCommand(msgType MessageType) *Command {
 	cmd := &Command{
 		Type:   msgType,
-		id:     "0",
+		id:     0,
 		fields: make(map[string]interface{}),
 	}
 
@@ -51,8 +52,8 @@ func (c *Command) AddParamField(value interface{}) *Command {
 	return c
 }
 
-func (c *Command) AddIdField(id string) *Command {
-	c.AddField("sequence_id", id)
+func (c *Command) AddIdField(id int) *Command {
+	c.AddField("sequence_id", strconv.Itoa(id))
 
 	return c
 }

--- a/internal/mqtt/command.go
+++ b/internal/mqtt/command.go
@@ -27,7 +27,7 @@ func NewCommand(msgType MessageType) *Command {
 		fields: make(map[string]interface{}),
 	}
 
-	return cmd.AddIdField(cmd.id)
+	return cmd.addIdField(cmd.id)
 
 }
 
@@ -52,7 +52,14 @@ func (c *Command) AddParamField(value interface{}) *Command {
 	return c
 }
 
-func (c *Command) AddIdField(id int) *Command {
+func (c *Command) addIdField(id int) *Command {
+	c.AddField("sequence_id", strconv.Itoa(id))
+
+	return c
+}
+
+func (c *Command) SetId(id int) *Command {
+	c.id = id
 	c.AddField("sequence_id", strconv.Itoa(id))
 
 	return c

--- a/internal/mqtt/command_test.go
+++ b/internal/mqtt/command_test.go
@@ -2,8 +2,9 @@ package mqtt
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCommand(t *testing.T) {

--- a/internal/mqtt/command_test.go
+++ b/internal/mqtt/command_test.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,13 @@ func TestCommand_AddParamField(t *testing.T) {
 	cmd := NewCommand(Print)
 	cmd.AddParamField("value")
 	assert.Equal(t, "value", cmd.fields["param"])
+}
+
+func TestCommand_SetId(t *testing.T) {
+	cmd := NewCommand(Print)
+	cmd.SetId(123)
+	assert.Equal(t, "123", cmd.fields["sequence_id"])
+	assert.Equal(t, "123", strconv.Itoa(cmd.id))
 }
 
 func TestCommand_JSON(t *testing.T) {

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -37,6 +37,7 @@ type Client struct {
 	mutex       sync.Mutex
 	data        Message
 	lastUpdate  time.Time
+	sequenceID  int
 	messageChan chan []byte
 	doneChan    chan struct{}
 	ticker      *time.Ticker
@@ -58,6 +59,7 @@ func NewClient(config *ClientConfig) *Client {
 		config:      config,
 		messageChan: make(chan []byte, 200),
 		doneChan:    make(chan struct{}),
+		sequenceID:  0,
 		ticker:      time.NewTicker(updateInterval),
 	}
 
@@ -92,6 +94,12 @@ func (c *Client) Disconnect() {
 
 // Publish sends a command message to the MQTT broker.
 func (c *Client) Publish(command *Command) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.sequenceID++
+	command.SetId(c.sequenceID)
+
 	rawCommand, err := command.JSON()
 	if err != nil {
 		return fmt.Errorf("failed to marshal command: %w", err)

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -12,6 +12,7 @@ import (
 	paho "github.com/eclipse/paho.mqtt.golang"
 )
 
+// TODO: Make these configurable
 const (
 	clientID       = "golang-bambulabs-api"
 	topicTemplate  = "device/%s/report"


### PR DESCRIPTION
Right now, sequence ids are always 0 on sent commands. This is deceptive to the recipient and provides no way to track how many commands are sent to the printer(s).

This pull request includes several changes to the `mqtt` package, focusing on modifying the `Command` structure to use an integer for the `id` field instead of a string, and adding functionality to manage the sequence ID in the `Client` struct.

Changes to `Command` structure:

* [`internal/mqtt/command.go`](diffhunk://#diff-da13f981d6ea6ecd7eb2a469faee174bb9dceb95a45630ff13f3bd69045ada71L17-R30): Changed the `id` field in the `Command` struct from a string to an integer and updated related methods to handle the integer type. Added the `SetId` method to set the `id` and update the `sequence_id` field accordingly. [[1]](diffhunk://#diff-da13f981d6ea6ecd7eb2a469faee174bb9dceb95a45630ff13f3bd69045ada71L17-R30) [[2]](diffhunk://#diff-da13f981d6ea6ecd7eb2a469faee174bb9dceb95a45630ff13f3bd69045ada71L54-R63)

Changes to `Client` structure:

* [`internal/mqtt/mqtt.go`](diffhunk://#diff-c69afebaa1404f855a10e10f268ad4b14a4c600949df79f7292cebc3ab8d4f11R40): Added a `sequenceID` field to the `Client` struct to keep track of command sequence IDs. Updated the `Publish` method to increment and set the `sequenceID` for each command before publishing. [[1]](diffhunk://#diff-c69afebaa1404f855a10e10f268ad4b14a4c600949df79f7292cebc3ab8d4f11R40) [[2]](diffhunk://#diff-c69afebaa1404f855a10e10f268ad4b14a4c600949df79f7292cebc3ab8d4f11R62) [[3]](diffhunk://#diff-c69afebaa1404f855a10e10f268ad4b14a4c600949df79f7292cebc3ab8d4f11R97-R102)

Test updates:

* [`internal/mqtt/command_test.go`](diffhunk://#diff-cd468a3154272f0c4e91af1a80ad45016b1a07af07ed985ad39f2b894c8d7e89R29-R35): Added a test for the new `SetId` method to ensure it correctly sets the `id` and updates the `sequence_id` field.

Import adjustments:

* [`internal/mqtt/command.go`](diffhunk://#diff-da13f981d6ea6ecd7eb2a469faee174bb9dceb95a45630ff13f3bd69045ada71R5): Added the `strconv` package to handle integer to string conversion for the `sequence_id` field.
* [`internal/mqtt/command_test.go`](diffhunk://#diff-cd468a3154272f0c4e91af1a80ad45016b1a07af07ed985ad39f2b894c8d7e89L5-R8): Adjusted imports to include `strconv` and reordered imports for better readability.