### PR TITLE
Remove raw println of commands

### DIFF
--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -131,8 +131,6 @@ func (c *Client) update() {
 
 	c.lastUpdate = time.Now()
 	command := NewCommand(Pushing).AddCommandField("pushall")
-	js, _ := command.JSON()
-	fmt.Println("command", js)
 	if err := c.Publish(command); err != nil {
 		log.Printf("Failed to publish update command: %v", err)
 	}


### PR DESCRIPTION
I assume this is some left-over debugging :)

If it's actually desired to log this we could change it to log.Printf instead? Just let me know!

(Thanks for this library, by the way; it's amazingly useful!)