### PR TITLE
Set mqtt timeout

### DIFF
--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -52,6 +52,8 @@ func NewClient(config *ClientConfig) *Client {
 		SetPassword(config.AccessCode).
 		SetTLSConfig(&tls.Config{InsecureSkipVerify: true}).
 		SetAutoReconnect(true).
+		SetConnectTimeout(10 * time.Second).
+		SetWriteTimeout(10 * time.Second).
 		SetKeepAlive(30 * time.Second)
 
 	client := &Client{


### PR DESCRIPTION
When printer is offline, cannot connnect to it. This patch set the mqtt connect/write timeout to 10 sec