### PR TITLE
feat: support custom light flashing timing

### DIFF
--- a/lights.go
+++ b/lights.go
@@ -1,5 +1,7 @@
 package bambulabs_api
 
+import "time"
+
 // Light is an enum representing all possible lights and their literal names as used in MQTT communications.
 type Light string
 
@@ -16,6 +18,24 @@ const (
 	LightOff      LightMode = "off"
 	LightFlashing LightMode = "flashing"
 )
+
+// LightFlashingConfig controls the timing of [LightFlashing].
+type LightFlashingConfig struct {
+	OnTime       time.Duration
+	OffTime      time.Duration
+	LoopTimes    int
+	IntervalTime time.Duration
+}
+
+// DefaultLightFlashingConfig returns the flashing configuration used by [Printer.SetLight].
+func DefaultLightFlashingConfig() LightFlashingConfig {
+	return LightFlashingConfig{
+		OnTime:       500 * time.Millisecond,
+		OffTime:      500 * time.Millisecond,
+		LoopTimes:    1,
+		IntervalTime: time.Second,
+	}
+}
 
 // I know what you're thinking but hear me out, the open-air printers use ChamberLight for their WorkLight which makes no sense
 // WorkLight is defined but not used so it'll likely change in the future

--- a/printer.go
+++ b/printer.go
@@ -46,6 +46,7 @@ type Printer interface {
 	RequestUpdate(ctx context.Context) error
 
 	SetLight(ctx context.Context, light Light, mode LightMode) error
+	SetLightFlashing(ctx context.Context, light Light, cfg LightFlashingConfig) error
 	SetFan(ctx context.Context, fan Fan, speed uint8) error
 	SendGcode(ctx context.Context, input []string) error
 
@@ -263,9 +264,19 @@ func (p *printer) DeleteFile(path string) error {
 // lights
 
 // SetLight publishes an MQTT command to control a given [Light], allowing you to set it to a given [LightMode].
-// For [LightMode.LightFlashing], a default configuration is used for the flashing length and frequency. Please see NOT IMPLEMENTED for more options.
+// For [LightFlashing], [DefaultLightFlashingConfig] is used. Call [Printer.SetLightFlashing] to customize the flashing timing.
 // If the [Printer] you attempt to call this function on does not support the chosen light, an [ErrLightNotSupported] will be returned.
 func (p *printer) SetLight(ctx context.Context, light Light, mode LightMode) error {
+	return p.setLight(ctx, light, mode, DefaultLightFlashingConfig())
+}
+
+// SetLightFlashing publishes an MQTT command that flashes a given [Light] using cfg.
+// If the [Printer] does not support the chosen light, an [ErrLightNotSupported] will be returned.
+func (p *printer) SetLightFlashing(ctx context.Context, light Light, cfg LightFlashingConfig) error {
+	return p.setLight(ctx, light, LightFlashing, cfg)
+}
+
+func (p *printer) setLight(ctx context.Context, light Light, mode LightMode, cfg LightFlashingConfig) error {
 	ctx, cancel := withDefaultOpTimeout(ctx)
 	defer cancel()
 
@@ -273,20 +284,24 @@ func (p *printer) SetLight(ctx context.Context, light Light, mode LightMode) err
 		return fmt.Errorf("%w: %s", ErrLightNotSupported, light)
 	}
 
-	command := protocol.NewCommand(protocol.System).
-		WithCommand("ledctrl").
-		Set("led_node", light).
-		Set("led_mode", mode).
-		Set("led_on_time", 500).
-		Set("led_off_time", 500).
-		Set("loop_times", 1).
-		Set("interval_time", 1000)
+	command := newLightCommand(light, mode, cfg)
 
 	if err := p.publish(ctx, command); err != nil {
 		return fmt.Errorf("error setting light %s: %w", light, err)
 	}
 
 	return nil
+}
+
+func newLightCommand(light Light, mode LightMode, cfg LightFlashingConfig) *protocol.Command {
+	return protocol.NewCommand(protocol.System).
+		WithCommand("ledctrl").
+		Set("led_node", light).
+		Set("led_mode", mode).
+		Set("led_on_time", cfg.OnTime.Milliseconds()).
+		Set("led_off_time", cfg.OffTime.Milliseconds()).
+		Set("loop_times", cfg.LoopTimes).
+		Set("interval_time", cfg.IntervalTime.Milliseconds())
 }
 
 // end lights

--- a/printer_test.go
+++ b/printer_test.go
@@ -2,6 +2,8 @@ package bambulabs_api
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -54,4 +56,50 @@ func TestWithDefaultOpTimeout(t *testing.T) {
 			t.Fatalf("deadline = %v, want %v", deadline, parentDeadline)
 		}
 	})
+}
+
+func TestNewLightCommand(t *testing.T) {
+	cfg := LightFlashingConfig{
+		OnTime:       250 * time.Millisecond,
+		OffTime:      750 * time.Millisecond,
+		LoopTimes:    3,
+		IntervalTime: 2 * time.Second,
+	}
+
+	payload, err := newLightCommand(ChamberLight, LightFlashing, cfg).Marshal()
+	if err != nil {
+		t.Fatalf("marshal light command: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal light command: %v", err)
+	}
+	want := map[string]any{
+		"system": map[string]any{
+			"command":       "ledctrl",
+			"sequence_id":   "0",
+			"led_node":      "chamber_light",
+			"led_mode":      "flashing",
+			"led_on_time":   float64(250),
+			"led_off_time":  float64(750),
+			"loop_times":    float64(3),
+			"interval_time": float64(2000),
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("light command = %#v, want %#v", got, want)
+	}
+}
+
+func TestDefaultLightFlashingConfig(t *testing.T) {
+	want := LightFlashingConfig{
+		OnTime:       500 * time.Millisecond,
+		OffTime:      500 * time.Millisecond,
+		LoopTimes:    1,
+		IntervalTime: time.Second,
+	}
+	if got := DefaultLightFlashingConfig(); got != want {
+		t.Fatalf("default flashing config = %#v, want %#v", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

- add `LightFlashingConfig` with custom on/off durations, loop count, and interval
- add `SetLightFlashing` while preserving the existing `SetLight` defaults
- cover both custom MQTT payload fields and the backward-compatible defaults

## Validation

- `go test ./...`
- `go vet ./...`
- `go generate ./...` (no generated diff)
- `git diff --check`

Fixes #121
